### PR TITLE
fix: whitelist external image domains in next.config.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,11 @@
 module.exports = {
   reactStrictMode: true,
   images: {
-    domains: ['guidelines.pr1mer.tech'],
+    domains: [
+      'guidelines.pr1mer.tech',
+      'images.pr1mer.tech',
+      'cdn-images-1.medium.com'
+    ],
   },
   typescript: {
     ignoreBuildErrors: true,


### PR DESCRIPTION
This PR fixes an issue where images from `images.pr1mer.tech` and `cdn-images-1.medium.com` were being blocked by the Next.js Image component because they were not whitelisted in the configuration.

### Changes
- Updated `next.config.js` to include `images.pr1mer.tech` and `cdn-images-1.medium.com` in the `images.domains` array.

This should restore visibility for many blog post cover images and inline assets.